### PR TITLE
feat: Add some mutexes to data and disk manager 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0.217", features = ["derive"] }
 bincode = "1.3.3"
+tempdir = "0.3.7"

--- a/examples/disk_scheduler_example.rs
+++ b/examples/disk_scheduler_example.rs
@@ -1,8 +1,0 @@
-use composter::disk_manager::{DiskManager, DiskRequest};
-use composter::disk_scheduler::DiskScheduler;
-use std::path::PathBuf;
-use std::sync::mpsc;
-
-fn main() {
-
-}

--- a/src/buffer_pool_manager.rs
+++ b/src/buffer_pool_manager.rs
@@ -64,9 +64,10 @@ impl BufferPoolManager {
 mod tests {
     use super::*;
     use crate::DEFAULT_PAGE_SIZE;
+    use std::sync::{Arc, Mutex};
     #[test]
     fn new_buffer_pool_manager() {
-        let disk_manager = DiskManager::default();
+        let disk_manager = Arc::new(Mutex::new(DiskManager::default()));
         let disk_scheduler = DiskScheduler::new(disk_manager);
         let replacer = Replacer::new(10);
         let buffer_pool_manager =

--- a/src/disk_scheduler.rs
+++ b/src/disk_scheduler.rs
@@ -1,37 +1,48 @@
-use crate::disk_manager::{DiskManager, DiskManagerRequest, DiskRequest};
-use std::sync::mpsc;
+use crate::disk_manager::{DiskManager, DiskManagerRequest};
 use std::sync::mpsc::{Receiver, Sender, TryRecvError};
+use std::sync::{mpsc, Arc, Mutex};
 
 /// [DiskScheduler] implements a IO scheduler for reading and writing
 /// from disk in to memory.
 pub struct DiskScheduler {
     /// channel is used a queue for disk reads and writes to be processed
     sender: Sender<DiskManagerRequest>,
+    disk_manager: Arc<Mutex<DiskManager>>,
 }
 
 impl DiskScheduler {
-    pub fn new(disk_manager: DiskManager) -> Self {
+    pub fn new(disk_manager: Arc<Mutex<DiskManager>>) -> Self {
         let (tx, rx) = mpsc::channel();
-        Self::spawn_worker(rx, disk_manager);
-        Self { sender: tx }
+        Self::spawn_worker(rx, disk_manager.clone());
+
+        Self {
+            sender: tx,
+            disk_manager,
+        }
     }
 
     pub fn spawn_worker(
         receiver: Receiver<DiskManagerRequest>,
-        mut disk_manager: DiskManager,
+        disk_manager: Arc<Mutex<DiskManager>>,
     ) -> std::thread::JoinHandle<()> {
         std::thread::spawn(move || loop {
             match receiver.try_recv() {
                 Ok(req) => match req {
-                    DiskManagerRequest::DiskRwRequest(req) => {
-                        if req.is_write {
-                            disk_manager.write_page(req);
+                    DiskManagerRequest::DiskRwRequest {
+                        is_write,
+                        data,
+                        page_id,
+                        callback,
+                    } => {
+                        let mut data = data.lock().unwrap();
+                        let mut_data = data.as_mut();
+                        let mut dm = disk_manager.lock().unwrap();
+                        if is_write {
+                            dm.write_page(mut_data, page_id, callback);
                         } else {
-                            disk_manager.read_page(req);
+                            dm.read_page(mut_data, page_id, callback);
                         }
                     }
-                    DiskManagerRequest::DiskIncreaseRequest(size) => {}
-                    DiskManagerRequest::DiskDecreaseRequest(size) => {}
                 },
                 Err(TryRecvError::Empty) => {
                     std::thread::sleep(std::time::Duration::from_millis(10));
@@ -43,59 +54,51 @@ impl DiskScheduler {
         })
     }
 
-    pub fn increase_size(
-        &mut self,
-        size: usize,
-    ) -> Result<(), mpsc::SendError<DiskManagerRequest>> {
-        self.sender
-            .send(DiskManagerRequest::DiskIncreaseRequest(size))
+    pub fn new_page(&mut self, size: usize) {
+        let mut dm = self.disk_manager.lock().unwrap();
+        dm.increase_pages(size);
     }
 
-    pub fn decrease_size(
+    pub fn request(
         &mut self,
-        size: usize,
+        is_write: bool,
+        data: Arc<Mutex<Vec<u8>>>,
+        page_id: usize,
+        callback: Sender<bool>,
     ) -> Result<(), mpsc::SendError<DiskManagerRequest>> {
-        self.sender
-            .send(DiskManagerRequest::DiskDecreaseRequest(size))
-    }
-
-    pub fn request(&self, request: DiskRequest) -> Result<(), mpsc::SendError<DiskManagerRequest>> {
-        self.sender.send(DiskManagerRequest::DiskRwRequest(request))
+        self.sender.send(DiskManagerRequest::DiskRwRequest {
+            is_write,
+            data,
+            page_id,
+            callback,
+        })
     }
 }
 
 mod tests {
     use super::*;
-    use std::path::PathBuf;
     #[test]
     fn test_disk_scheduler() {
-        let mut counter = 0;
-        let (tx, rx) = mpsc::channel();
-        let dm = DiskManager::new(4096, None, true);
-        let ds = DiskScheduler::new(dm);
+        let (call_tx, call_rx) = mpsc::channel();
+        let dm = Arc::new(Mutex::new(DiskManager::new(4096, None, true)));
+        let mut ds = DiskScheduler::new(dm);
 
         let b = std::thread::spawn(move || {
-            for i in 0..10 {
-                ds.request(DiskRequest {
-                    is_write: false,
-                    data: vec![],
-                    page_id: i,
-                    callback: tx.clone(),
-                })
-                .unwrap();
+            for i in 1..10 {
+                let v = Arc::new(Mutex::new(vec![0; 1024]));
+                ds.new_page(i);
+                ds.request(false, v, i, call_tx.clone()).unwrap();
             }
         });
 
         let a = std::thread::spawn(move || {
-            while let Ok(val) = rx.recv() {
-                assert_eq!(val, true);
-                counter = counter + 1;
+            while let Ok(val) = call_rx.recv() {
+                assert!(val);
+                println!("ok");
             }
         });
 
         b.join().unwrap();
         a.join().unwrap();
-
-        assert_eq!(counter, 10);
     }
 }


### PR DESCRIPTION
Need to be able to pass a mutable reference as data through the disk scheduler channels. 
Previously when I was attempting to use a Vec<u8> that clearly was not working since I could not use it after 
passing it in to the disk manager. 

This PR removes DiskRequest and instead uses an Enum (for extensibility if needed). I pass an Arc<Mutex>> for data instead of a Vec<u8> so the data is thread safe and can be accessed after its been mutably borrowed within the disk manager. 